### PR TITLE
Potential fix for code scanning alert no. 1: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.15.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,6 +8,7 @@ import express, { urlencoded, json } from "express";
 import morgan from "morgan";
 // Importa el módulo 'cookie-parser' para manejar las cookies
 import cookieParser from "cookie-parser";
+import { csrf } from "lusca";
 /** El enrutador principal */
 import indexRoutes from "./routes/index.routes.js";
 // Importa el archivo 'configDB.js' para crear la conexión a la base de datos
@@ -32,6 +33,8 @@ async function setupServer() {
     server.use(json());
     // Agregamos el middleware para el manejo de cookies
     server.use(cookieParser());
+    // Agregamos el middleware para la protección CSRF
+    server.use(csrf());
     // Agregamos morgan para ver las peticiones que se hacen al servidor
     server.use(morgan("dev"));
     // Agrega el enrutador principal al servidor


### PR DESCRIPTION
Potential fix for [https://github.com/VAC-Escuela-de-Musica/escuela-musica/security/code-scanning/1](https://github.com/VAC-Escuela-de-Musica/escuela-musica/security/code-scanning/1)

To fix the issue, we need to add CSRF protection middleware to the server. The `lusca` library is a well-known and reliable choice for this purpose. Specifically, we will use its `csrf` middleware to ensure that all state-changing requests include a valid CSRF token. This token will be generated and validated for each session.

Steps to implement the fix:
1. Install the `lusca` package if it is not already installed.
2. Import the `csrf` middleware from `lusca`.
3. Add the `csrf` middleware to the server setup, ensuring it is applied after `cookieParser()` and before any state-changing routes.
4. Optionally, configure the middleware to exclude specific routes (e.g., public APIs) if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
